### PR TITLE
Add support for more IDEs

### DIFF
--- a/src/com/tsunderebug/discordintellij/package.scala
+++ b/src/com/tsunderebug/discordintellij/package.scala
@@ -4,13 +4,17 @@ package object discordintellij {
 
   def getIDEName(code: String): String = {
     code match {
-      case "ic" | "iu" => "IntelliJ"
+      case "ic" | "iu" => "IntelliJ IDEA"
       case "py" | "pc" | "pe" => "PyCharm"
       case "rm" => "RubyMine"
       case "go" => "GoLand"
       case "cl" => "CLion"
       case "ps" => "PhpStorm"
       case "ws" => "WebStorm"
+      case "ac" => "AppCode"
+      case "mp" => "MPS"
+      case "db" => "DataGrip"
+      case "rd" => "Rider"
       case _ => s"[Unknown IDE ${code.toUpperCase}]"
     }
   }


### PR DESCRIPTION
This time, I added support for AppCode (a macOS exclusive IDE), MPS, DataGrip, and Rider.

I also changed the name of the Java IDE from "IntelliJ" to "IntelliJ IDEA" because all the IDEs are essentially IntelliJ and "IDEA" give the Java IDE a little boost lol.

Chao